### PR TITLE
Change JWT core from being an implicit dependency to explicit one, and bump to `v1.87.0`.

### DIFF
--- a/EqualityInformationApi/EqualityInformationApi.csproj
+++ b/EqualityInformationApi/EqualityInformationApi.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />


### PR DESCRIPTION
# What:
 - Make `Hackney.Core.JWT` be an **explicit** dependency instead of an **implicit** one.
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.30 -> ... -> 1.87)_.

# Why:
 - This C# solution is **directly** referencing the JWT core package across both its projects: using JWT namespaces, methods, and interfaces. Issue is that this package is **not referenced as a direct dependency** within the `.csproj` files. Instead, package is imported through `Hackney.Core.Authorization`. When the restore happens, Authorization package is build, which contains the binaries from JWT due to a weak link between the 2.
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - What changes does latest JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.
 - **These changes do not require immediate deployment**, they merely need to be present within the repo's main branch. This is so those changes would already be there for when anyone would introduce new changes attempting to access Google groups from the token. Without this JWT version bump, any attempted access of Groups within the token would make the API wouldn't fall over.