### PR TITLE
Release #45 and #46 to staging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - run:
           name: build

--- a/EqualityInformationApi/EqualityInformationApi.csproj
+++ b/EqualityInformationApi/EqualityInformationApi.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />

--- a/EqualityInformationApi/serverless.yml
+++ b/EqualityInformationApi/serverless.yml
@@ -185,7 +185,7 @@ resources:
 
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   safeguards:


### PR DESCRIPTION
# What:
 - Release #45 _(only affects dev)_.
 - Release #46 _(release target)_.

# Why:
 - Preparation for deploying Cognito authentication to staging. Ensuring that all APIs are able to handle both token schemas by pointing them to the latest Nuget JWT package version.