### PR TITLE
Switch to the Cognito authorizer on staging environment.

### DIFF
--- a/EqualityInformationApi/serverless.yml
+++ b/EqualityInformationApi/serverless.yml
@@ -186,7 +186,7 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer


### PR DESCRIPTION
# What:
 - Switch to the Cognito authorizer on staging environment.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `staging`.