### PR TITLE
SSI-1140 Remove stg canary

### DIFF
--- a/EqualityInformationApi/serverless.yml
+++ b/EqualityInformationApi/serverless.yml
@@ -53,20 +53,11 @@ functions:
           private: false
 resources:
   Conditions:
-    # Only create the Canaries for staging/prod
-    IsProdDeployment:
+    # Only create the Canary for prod
+    CreateCanary:
       Fn::Equals:
         - ${self:provider.stage}
         - production
-    IsStagingDeployment:
-      Fn::Equals:
-        - ${self:provider.stage}
-        - staging
-    # Check if deployment is staging or prod
-    CreateCanary:
-      Fn::Or:
-        - Condition: IsStagingDeployment
-        - Condition: IsProdDeployment
   Resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role


### PR DESCRIPTION
## Link to JIRA ticket

[SSI-1140](https://hackney.atlassian.net/browse/SSI-1140)

## Describe this PR

### *What is the problem we're trying to solve*

Currently this Canary is failing on staging due to invalid token configuration. We can see errors in the Lambda authorizer log that shows it's tyring to use non-existent token when trying to call the healthcheck endpoint in this API. This floods the authorizer logs with nuisance errors that makes troubleshooting and monitoring more difficult.

This Canary don't really provide any value on staging and no one is currently monitoring the state of it. It also incurs unnecesary costs.

For future reference this Canary can be added back by using correct configuration. The `TOKEN` environment variable set for the Canary in the Serverless config must use valid service token for this API. 

### *What changes have we introduced*

Remove the staging Canary and only deploy it to prod.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Release to staging and check that the Canary has been removed.

[SSI-1140]: https://hackney.atlassian.net/browse/SSI-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ