### PR TITLE
Release PR #52.

### DIFF
--- a/EqualityInformationApi/serverless.yml
+++ b/EqualityInformationApi/serverless.yml
@@ -178,7 +178,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-gateway-lambda-authorizer
   safeguards:
     - title: Require authorizer
       safeguard: require-authorizer


### PR DESCRIPTION
# What:
- Release #52 to `production`.

# Notes:
 - It's unclear why the tests show as failing. Based on the pipeline they all passed, but some sort of DynamoDB concurrency error was thrown. Perhaps, some tests dependency version bump introduced breaking changes. Either that, or it's a one-off. Will try merging to release. If the error is consistent - will fix it in the next PR.
 - Released changes have no impact on tests.